### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/cfn/adx-cfn-alphavantage.json
+++ b/cfn/adx-cfn-alphavantage.json
@@ -353,7 +353,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": 60
             },
             "Metadata": {

--- a/cfn/adx-cfn-rearc.json
+++ b/cfn/adx-cfn-rearc.json
@@ -353,7 +353,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": 60
             },
             "Metadata": {

--- a/cfn/adx-cfn-sp500.json
+++ b/cfn/adx-cfn-sp500.json
@@ -353,7 +353,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": 60
             },
             "Metadata": {

--- a/cfn/cfn-put-dynamodb-item-cfn.json
+++ b/cfn/cfn-put-dynamodb-item-cfn.json
@@ -61,7 +61,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": 60
             }
         },


### PR DESCRIPTION
CloudFormation templates in aws-data-exchange-amazon-finspace-integration have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.